### PR TITLE
docs: add hardware compatibility table

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,11 @@ to record test results before changing active BLE behavior again.
 Manual install instructions are in [docs/INSTALL_MANUAL.md](docs/INSTALL_MANUAL.md). The install
 requires copying only `custom_components/aruba_ble_proxy`.
 
+## Hardware Compatibility
+
+Community-tested hardware and firmware combinations are tracked in
+[docs/HARDWARE_COMPATIBILITY.md](docs/HARDWARE_COMPATIBILITY.md).
+
 ## License
 
 This project is licensed under the **GNU General Public License v3.0**. See [LICENSE](LICENSE).

--- a/docs/HARDWARE_COMPATIBILITY.md
+++ b/docs/HARDWARE_COMPATIBILITY.md
@@ -1,0 +1,21 @@
+# Hardware Compatibility
+
+This document collects community-reported hardware and firmware combinations tested with Aruba BLE Proxy.
+
+| Device | Firmware / Platform | Deployment Mode | Passive BLE | Active BLE / GATT | Tested By | Notes |
+| --- | --- | --- | --- | --- | --- | --- |
+| Aruba AP-505 | Aruba Instant 8.12.0.3_91078 | Instant | Confirmed in Home Assistant Bluetooth dashboard | Not tested | Community report | BLE advertisements visible in Home Assistant. |
+| Aruba AP-535 | Aruba Instant 8.12.0.3_91078 | Instant | Confirmed in Home Assistant Bluetooth dashboard | Not tested | Community report | BLE advertisements visible in Home Assistant. |
+| Aruba AP-515 | ArubaOS 8.12 | Mobility Gateway | Reported, not yet confirmed | Not tested | Community report | User reported AP-515 with AOS 8.12 and a Mobility Gateway. |
+| Aruba AP-365 | Unknown | Unknown | Reported working | Not tested | Community report | Firmware and deployment mode still need confirmation. |
+
+## Reporting new results
+
+Please include:
+
+- AP model
+- firmware version
+- deployment mode, such as Instant or controller-managed
+- whether passive BLE advertisements are visible in Home Assistant
+- whether active BLE/GATT was tested
+- any custom Aruba filters that were required


### PR DESCRIPTION
Adds a community-maintained hardware compatibility document to track tested AP models, firmware versions, deployment modes, and validation status.

This is intended to collect real-world reports from users and make it easier to identify known-working Aruba hardware combinations.