### PR TITLE
Encode Bluetooth SIG UUIDs in native 16-bit form

### DIFF
--- a/custom_components/aruba_ble_proxy/aruba_iot_ble/active.py
+++ b/custom_components/aruba_ble_proxy/aruba_iot_ble/active.py
@@ -85,9 +85,18 @@ def uuid_to_bytes(value: str | None) -> bytes:
         return b""
     cleaned = value.strip().replace("-", "")
     if len(cleaned) == 4:
-        cleaned = f"0000{cleaned}00001000800000805f9b34fb"
+        return bytes.fromhex(cleaned)
     if len(cleaned) != 32:
         raise ValueError(f"Invalid BLE UUID: {value}")
+    # Aruba AOS matches Bluetooth SIG UUIDs by their native 16-bit wire form.
+    # Bleak commonly supplies the equivalent 128-bit Bluetooth Base UUID, so
+    # compress that representation before sending a southbound action. Custom
+    # 128-bit UUIDs must remain 16 bytes.
+    if (
+        cleaned.startswith("0000")
+        and cleaned[8:] == "00001000800000805f9b34fb"
+    ):
+        return bytes.fromhex(cleaned[4:8])
     return bytes.fromhex(cleaned)
 
 

--- a/tests/test_active.py
+++ b/tests/test_active.py
@@ -71,8 +71,19 @@ def test_encode_gatt_read_accepts_short_uuid():
     message.ParseFromString(payload)
 
     assert message.actions[0].type == aruba_iot_types_pb2.gattRead
-    assert message.actions[0].serviceUuid == uuid_to_bytes("0000180f-0000-1000-8000-00805f9b34fb")
-    assert message.actions[0].characteristicUuid == uuid_to_bytes("00002a19-0000-1000-8000-00805f9b34fb")
+    assert message.actions[0].serviceUuid == bytes.fromhex("180f")
+    assert message.actions[0].characteristicUuid == bytes.fromhex("2a19")
+
+
+def test_uuid_to_bytes_compresses_bluetooth_base_uuid_only():
+    """Native SIG UUIDs are short; vendor-specific UUIDs stay 128-bit."""
+    assert uuid_to_bytes("180f") == bytes.fromhex("180f")
+    assert uuid_to_bytes("0000180f-0000-1000-8000-00805f9b34fb") == bytes.fromhex(
+        "180f"
+    )
+    assert uuid_to_bytes("12345678-1234-5678-1234-567812345678") == bytes.fromhex(
+        "12345678123456781234567812345678"
+    )
 
 
 def test_encode_gatt_notification_carries_enable_value():


### PR DESCRIPTION
## Summary

Aruba AOS BLE southbound GATT actions expect Bluetooth SIG services and characteristics in their native 16-bit UUID wire representation. Bleak commonly exposes the same UUIDs in canonical 128-bit Base UUID form, which currently causes active GATT actions to be rejected or remain disconnected.

This change:

- sends already-short UUIDs as their native 2-byte value;
- compresses canonical Bluetooth Base UUIDs (`0000xxxx-0000-1000-8000-00805f9b34fb`) to the same 2-byte value;
- preserves vendor-specific 128-bit UUIDs unchanged.

## Validation

- `python -m pytest -q --asyncio-mode=auto tests/test_active.py` (10 passed)
- Added coverage for standard, canonical Base UUID, and vendor-specific UUID forms.